### PR TITLE
Fix renamed CommandLineOption

### DIFF
--- a/binary-analysis/scancode-compiledcode/src/cppincludes/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/cppincludes/__init__.py
@@ -31,8 +31,8 @@ import attr
 from textcode import analysis
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from typecode import contenttype
 
 
@@ -46,7 +46,7 @@ class CPPIncludesScanner(ScanPlugin):
     )
 
     options = [
-        CommandLineOption(('--cpp-includes',),
+        PluggableCommandLineOption(('--cpp-includes',),
             is_flag=True, default=False,
             help='Collect the #includes statements in a C/C++ file.',
             help_group=SCAN_GROUP,

--- a/binary-analysis/scancode-compiledcode/src/dwarf/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/dwarf/__init__.py
@@ -35,8 +35,8 @@ import attr
 from commoncode import fileutils
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from typecode import contenttype
 
 from dwarf import dwarf
@@ -52,7 +52,7 @@ class DwarfScanner(ScanPlugin):
         dwarf_source_path=attr.ib(default=attr.Factory(list), repr=False))
 
     options = [
-        CommandLineOption(('--dwarf',),
+        PluggableCommandLineOption(('--dwarf',),
             is_flag=True, default=False,
             help='Collect source code path from compilation units found in '
                  'ELF DWARFs.',

--- a/binary-analysis/scancode-compiledcode/src/elf/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/elf/__init__.py
@@ -33,8 +33,8 @@ import attr
 from commoncode import fileutils
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from typecode import contenttype
 
 from elf.elf import Elf
@@ -50,7 +50,7 @@ class ELFScanner(ScanPlugin):
     )
 
     options = [
-        CommandLineOption(('--elf',),
+        PluggableCommandLineOption(('--elf',),
             is_flag=True, default=False,
             help='Collect the names of shared objects/libraries needed by an Elf binary file.',
             help_group=SCAN_GROUP,

--- a/binary-analysis/scancode-compiledcode/src/generatedcode/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/generatedcode/__init__.py
@@ -38,8 +38,8 @@ import commoncode.text
 
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from textcode import analysis
 from typecode import contenttype
 
@@ -54,7 +54,7 @@ class GeneratedCodeScanner(ScanPlugin):
     )
 
     options = [
-        CommandLineOption(('--generatedcode',),
+        PluggableCommandLineOption(('--generatedcode',),
                           is_flag=True, default=False,
                           help='Get the snippet that is possibly generated code.',
                           help_group=SCAN_GROUP,

--- a/binary-analysis/scancode-compiledcode/src/gwt/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/gwt/__init__.py
@@ -34,8 +34,8 @@ import attr
 
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from textcode import analysis
 from typecode import contenttype
 
@@ -52,7 +52,7 @@ class GWTScanner(ScanPlugin):
     )
 
     options = [
-        CommandLineOption(('--gwt',),
+        PluggableCommandLineOption(('--gwt',),
                           is_flag=True, default=False,
                           help='Parse GWT (Google Web Toolkit) ".symbolMap" files to extract compilation/debug symbols. Used to infer the relationship between the compiled JavaScript and the original Java Source code.',
                           help_group=SCAN_GROUP,

--- a/binary-analysis/scancode-compiledcode/src/lkmclue/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/lkmclue/__init__.py
@@ -30,8 +30,8 @@ import attr
 from commoncode import fileutils
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from typecode import contenttype
 
 from sourcecode import kernel
@@ -47,7 +47,7 @@ class LKMClueScanner(ScanPlugin):
     )
 
     options = [
-        CommandLineOption(('--lkmclue',),
+        PluggableCommandLineOption(('--lkmclue',),
             is_flag=True, default=False,
             help='Collect LKM module clues and type indicating a possible Linux Kernel Module. (formerly lkm_hint and lkm_line).',
             help_group=SCAN_GROUP,

--- a/binary-analysis/scancode-compiledcode/src/makedepend/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/makedepend/__init__.py
@@ -34,8 +34,8 @@ import attr
 from commoncode import fileutils
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from typecode import contenttype
 
 
@@ -49,7 +49,7 @@ class MakeDependScanner(ScanPlugin):
     )
 
     options = [
-        CommandLineOption(('--makedepend',),
+        PluggableCommandLineOption(('--makedepend',),
                           is_flag=True, default=False,
                           help='Parse generated make depend files to find sources corresponding binaries.',
                           help_group=SCAN_GROUP,

--- a/binary-analysis/scancode-compiledcode/src/sourcecode/__init__.py
+++ b/binary-analysis/scancode-compiledcode/src/sourcecode/__init__.py
@@ -33,8 +33,8 @@ import attr
 from commoncode import fileutils
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import SCAN_GROUP
 from typecode import contenttype
 
 from sourcecode import kernel
@@ -53,7 +53,7 @@ class CodeCommentLinesScanner(ScanPlugin):
     )
 
     options = [
-        CommandLineOption(('--codecommentlines',),
+        PluggableCommandLineOption(('--codecommentlines',),
             is_flag=True, default=False,
             help='  Scan the number of lines of code and lines of the comments.',
             help_group=SCAN_GROUP,

--- a/misc/scancode-fingerprint/src/plugin_fingerprint/plugin_fingerprint.py
+++ b/misc/scancode-fingerprint/src/plugin_fingerprint/plugin_fingerprint.py
@@ -31,9 +31,9 @@ import attr
 
 from plugincode.scan import ScanPlugin
 from plugincode.scan import scan_impl
-from scancode import CommandLineOption
-from scancode import OTHER_SCAN_GROUP
-from scancode import SCAN_OPTIONS_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import OTHER_SCAN_GROUP
+from commoncode.cliutils import SCAN_OPTIONS_GROUP
 from plugin_fingerprint.fingerprint import Simhash
 
 @scan_impl
@@ -46,7 +46,7 @@ class FingerprintScanner(ScanPlugin):
     sort_order = 1
 
     options = [
-        CommandLineOption(('-f', '--fingerprint'),
+        PluggableCommandLineOption(('-f', '--fingerprint'),
                           is_flag=True, default=False,
                           help='Scan <input> to generate simhash fingerprints for similarity matching.',
                           help_group=OTHER_SCAN_GROUP)

--- a/misc/scancode-ignore-binaries/src/scanignobin/__init__.py
+++ b/misc/scancode-ignore-binaries/src/scanignobin/__init__.py
@@ -29,8 +29,8 @@ from functools import partial
 
 from plugincode.pre_scan import PreScanPlugin
 from plugincode.pre_scan import pre_scan_impl
-from scancode import CommandLineOption
-from scancode import PRE_SCAN_GROUP
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import PRE_SCAN_GROUP
 from typecode.contenttype import get_type
 
 
@@ -41,7 +41,7 @@ class IgnoreBinaries(PreScanPlugin):
     """
 
     options = [
-        CommandLineOption(('--ignore-binaries',),
+        PluggableCommandLineOption(('--ignore-binaries',),
            is_flag=True,
            help='Ignore binary files.',
            sort_order=10,


### PR DESCRIPTION
This PR fixes the plugins after CommandLineOption was renamed to PluggableCommandLineOption in the scancode package.