### PR TITLE
Replace freenode references with libera chat

### DIFF
--- a/builtins/extractcode_libarchive-linux/src/extractcode_libarchive/licenses/xz/README
+++ b/builtins/extractcode_libarchive-linux/src/extractcode_libarchive/licenses/xz/README
@@ -230,7 +230,5 @@ XZ Utils
     I'm sometimes slow at replying. If you haven't got a reply within two
     weeks, assume that your email has got lost and resend it or use IRC.
 
-    You can find me also from #tukaani on Freenode; my nick is Larhzu.
-    The channel tends to be pretty quiet, so just ask your question and
-    someone may wake up.
-
+    You can join us on the Gitter chat channel at https://gitter.im/aboutcode-org/discuss
+    or also can use your favorite IRC client at https://web.libera.chat/?#aboutcode .

--- a/builtins/extractcode_libarchive-macosx/src/extractcode_libarchive/licenses/xz/README
+++ b/builtins/extractcode_libarchive-macosx/src/extractcode_libarchive/licenses/xz/README
@@ -230,7 +230,5 @@ XZ Utils
     I'm sometimes slow at replying. If you haven't got a reply within two
     weeks, assume that your email has got lost and resend it or use IRC.
 
-    You can find me also from #tukaani on Freenode; my nick is Larhzu.
-    The channel tends to be pretty quiet, so just ask your question and
-    someone may wake up.
-
+    You can join us on the Gitter chat channel at https://gitter.im/aboutcode-org/discuss
+    or also can use your favorite IRC client at https://web.libera.chat/?#aboutcode .


### PR DESCRIPTION
**Reference Issues/PRs**

Fixes [Replace references to freenode #92](https://github.com/nexB/aboutcode/issues/92)

**What does this implement/fix? Explain your changes.**
There were some outdated freenode references present in README so replaced this address with the official IRC channel i.e Gitter and liberachat

**Any other comments?**
Thank You!